### PR TITLE
prevent possible word splitting in the binary path

### DIFF
--- a/payload.tmp/bin/bwa-bwasw-wrapper.sh
+++ b/payload.tmp/bin/bwa-bwasw-wrapper.sh
@@ -10,7 +10,7 @@
 
 # Include helper functions
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-. ${DIR}/wrapper_utils.sh
+. "${DIR}"/wrapper_utils.sh
 
 # ---------------------------------------------------------------------------
 # Cleanup at Exit

--- a/payload.tmp/bin/bwa-sampe-wrapper.sh
+++ b/payload.tmp/bin/bwa-sampe-wrapper.sh
@@ -10,7 +10,7 @@
 
 # Include helper functions
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-. ${DIR}/wrapper_utils.sh
+. "${DIR}"/wrapper_utils.sh
 
 # ---------------------------------------------------------------------------
 # Cleanup at Exit

--- a/payload.tmp/bin/bwa-samse-wrapper.sh
+++ b/payload.tmp/bin/bwa-samse-wrapper.sh
@@ -9,7 +9,7 @@
 
 # Include helper functions
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-. ${DIR}/wrapper_utils.sh
+. "${DIR}"/wrapper_utils.sh
 
 # ---------------------------------------------------------------------------
 # Cleanup at Exit


### PR DESCRIPTION
The path to the binaries can contain whitespace, which is why quoting of $DIR is necessary for a consistent result. 

In my case (Mac OSX) the path was:

    /Applications/KNIME 3.6.1.app/Contents/Eclipse/plugins/de.seqan.ngs_toolbox.macosx.x86_64_0.1.0.201807231601/payload/bin

Without quotations the above string is split after "KNIME", so that the source command fails.